### PR TITLE
Remove passivequeue.pro domain references

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -213,7 +213,7 @@
             </div>
 
 
-<a class="btn btn-ghost text-xl font-light" href="https://passivequeue.pro">
+<a class="btn btn-ghost text-xl font-light" href="https://github.com/mensfeld/passive_queue">
     <img src="logo.svg" alt="Passive Queue Logo" 
          class="w-16 h-16 mx-auto mb-0 block mr-2 logo-light hidden" id="" style="width: 28px; height: 28px;">
     <!-- Dark mode logo -->

--- a/passive_queue.gemspec
+++ b/passive_queue.gemspec
@@ -4,15 +4,15 @@ Gem::Specification.new do |spec|
   spec.name = "passive_queue"
   spec.version = PassiveQueue::VERSION
   spec.authors = ["Maciej Mensfeld"]
-  spec.email = ["void@passivequeue.pro"]
+  spec.email = ["maciej@mensfeld.pl"]
 
   spec.summary = "A Rails queue adapter that embraces the zen of non-productivity"
   spec.description = "Rails queue adapter for mindful developers. Accepts all jobs, executes none. Perfect reliability through strategic non-action."
-  spec.homepage = "https://passivequeue.pro"
+  spec.homepage = "https://github.com/mensfeld/passive_queue"
   spec.license = "MIT"
   spec.required_ruby_version = ">= 3.3.0"
 
-  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["homepage_uri"] = "https://github.com/mensfeld/passive_queue"
   spec.metadata["source_code_uri"] = "https://github.com/mensfeld/passive_queue"
   spec.metadata["changelog_uri"] = "https://github.com/mensfeld/passive_queue/blob/main/CHANGELOG.md"
 


### PR DESCRIPTION
## Summary

- Replace `passivequeue.pro` with GitHub repo URL in `passive_queue.gemspec` (homepage, homepage_uri, email)
- Replace `passivequeue.pro` link in `html/index.html` nav logo

## Why

Domain is expiring and not worth renewing.