### PR TITLE
Remove passivequeue.io email reference

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -568,7 +568,7 @@ end
                             </li>
                         </ul>
                         <div class="card-actions justify-center mt-6">
-                            <a href="mailto:void@passivequeue.io" class="btn btn-outline btn-wide">Contact Sales</a>
+                            <a href="mailto:maciej@mensfeld.pl" class="btn btn-outline btn-wide">Contact Sales</a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary

- Replace `mailto:void@passivequeue.io` in the "Contact Sales" button in `html/index.html` with the real email address

## Why

Domain is expiring and not worth renewing.