### PR TITLE
Release 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@ All notable changes to this project will be documented in this file. Since this 
 
 ## [Unreleased]
 
-### Added
-- Minitest test suite with Minitest::Spec style tests
+## [1.1.1] - 2026-05-18
+
+### Changed
+- Replaced expired `passivequeue.pro` and `passivequeue.io` domain references with the GitHub repository URL and maintainer email
 
 ## [1.1.0] - 2025-11-13
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    passive_queue (1.1.0)
+    passive_queue (1.1.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/passive_queue/version.rb
+++ b/lib/passive_queue/version.rb
@@ -3,5 +3,5 @@
 # ================================
 module PassiveQueue
   # 1.0 so stable and production ready
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end


### PR DESCRIPTION
## Summary

- Bump version to `1.1.1`
- Update `CHANGELOG.md` with 1.1.1 entry covering the domain cleanup from #58 and #59

## Changes since 1.1.0

- Replaced expired `passivequeue.pro` and `passivequeue.io` domain references with the GitHub repo URL and maintainer email