### PR TITLE
Fix SimpleCov add_filter deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
         with:
-          ruby-version: '4.0.5'
+          ruby-version: '4.0'
           bundler-cache: true
       - name: Run Tests
         run: bundle exec rake test
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
         with:
-          ruby-version: '4.0.5'
+          ruby-version: '4.0'
           bundler-cache: true
       - name: Run Yard-Lint
         run: bundle exec yard-lint lib/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,6 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    docile (1.4.1)
     drb (2.2.3)
     minitest (6.0.6)
       drb (~> 2.0)
@@ -14,12 +13,7 @@ GEM
     prism (1.9.0)
     rack (3.2.6)
     rake (13.4.2)
-    simplecov (0.22.0)
-      docile (~> 1.1)
-      simplecov-html (~> 0.11)
-      simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.13.2)
-    simplecov_json_formatter (0.1.4)
+    simplecov (1.0.0)
 
 PLATFORMS
   ruby

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,9 +5,9 @@ require 'simplecov'
 SimpleCov.start do
   enable_coverage :branch
   minimum_coverage line: 95, branch: 90
-  add_filter '/test/'
-  add_filter '/lib/passive_queue/railtie.rb'
-  add_filter '/lib/active_job/'
+  skip '/test/'
+  skip '/lib/passive_queue/railtie.rb'
+  skip '/lib/active_job/'
 end
 
 require 'minitest/autorun'


### PR DESCRIPTION
## What

Fixes the SimpleCov `add_filter` deprecation and keeps CI on the newest Ruby 4.0 patch.

### SimpleCov 1.0.0
- `Gemfile.lock` bumped to `simplecov (1.0.0)`.
- `test/test_helper.rb`: renamed the deprecated `add_filter` calls to `skip`, which is the SimpleCov 1.0 API.

### CI
- `.github/workflows/ci.yml`: `ruby-version` loosened from the exact `'4.0.5'` pin to `'4.0'` in both the `test` and `yard-lint` jobs, so `setup-ruby` resolves the latest 4.0 patch automatically instead of needing a bump PR each release.
- Coverage runs in the `test` job, which is now on Ruby 4.0.LATEST — so coverage is measured on Ruby 4.